### PR TITLE
fix: cast v_constraintrec.constraint_name to text

### DIFF
--- a/pg_get_tabledef.sql
+++ b/pg_get_tabledef.sql
@@ -270,7 +270,7 @@ NO OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFI
           END IF;
       END IF;
       -- RAISE INFO 'DEBUG4: constraint name= %', v_constraintrec.constraint_name;    
-      constraintarr := constraintarr || v_constraintrec.constraint_name;
+      constraintarr := constraintarr || v_constraintrec.constraint_name:: text;
 
       IF fktype <> 'FKEYS_INTERNAL' AND v_constraintrec.constraint_type = 'f' THEN
           continue;


### PR DESCRIPTION
I got error on PostgreSQL 12 when running the function
```
NOTICE:  version=120014
INFO:  (1)tabledef so far: <NULL>
INFO:  (2)tabledef so far: CREATE  TABLE public.....

Query 1 ERROR: ERROR:  line=PL/pgSQL function pg_get_tabledef(character varying,character varying,
boolean,tabledefs[]) line 235 at assignment. 42883. operator does not exist: text[] || name
CONTEXT:  PL/pgSQL function pg_get_tabledef(character varying,character varying,
boolean,tabledefs[]) line 354 at RAISE
```

After casting `v_constraintrec.constraint_name` to text, the function works properly