### PR TITLE
Fix typo and other minor tweaks to change history comments

### DIFF
--- a/pg_get_tabledef.sql
+++ b/pg_get_tabledef.sql
@@ -1,7 +1,7 @@
 -- Change History:
--- 2022-09-19  MJV FIX: Do not add CREATE INDEX statements if they indexes are defined within the Table definition as ADD CONSTRAINT.
--- 2022-12-03  MJV FIX: Handle NULL condition for ENUMs
--- 2022-12-07  MJV FIX: not setting tablespace correctly for user defined tablespaces
+-- 2022-09-19  MJV FIX: Do not add CREATE INDEX statements if the indexes are defined within the table definition as ADD CONSTRAINT.
+-- 2022-12-03  MJV FIX: Handle NULL condition for ENUMs.
+-- 2022-12-07  MJV FIX: Handle setting tablespace correctly for user-defined tablespaces.
 do $$ 
 <<first_block>>
 DECLARE


### PR DESCRIPTION
Should these entries in the change history at the top be merged with the history entries below the copyright notice? I'm not clear as to why there are two histories. Is the first one just for changes to the first section of the code?