### PR TITLE
fix: quote columns that use reserved postgres keywords

### DIFF
--- a/pg_get_tabledef.sql
+++ b/pg_get_tabledef.sql
@@ -319,8 +319,8 @@ NO OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFI
          END IF;
          
          --v17 put double-quotes around case-sensitive column names
-         SELECT COUNT(*) INTO v_cnt FROM information_schema.columns t WHERE EXISTS (SELECT REGEXP_MATCHES(s.column_name, '([A-Z]+)','g') FROM information_schema.columns s 
-         WHERE t.table_schema=s.table_schema and t.table_name=s.table_name and t.column_name=s.column_name AND t.table_schema = quote_ident(in_schema) AND column_name = v_colrec.column_name);         
+         SELECT COUNT(*) INTO v_cnt FROM information_schema.columns t WHERE EXISTS (SELECT s.column_name FROM information_schema.columns s 
+         WHERE t.table_schema=s.table_schema and t.table_name=s.table_name and t.column_name=s.column_name AND t.table_schema = quote_ident(in_schema) AND column_name = v_colrec.column_name AND (s.column_name ~ '[A-Z]+' OR s.column_name IN (SELECT word FROM pg_get_keywords() WHERE catdesc = 'reserved')));
          IF v_cnt > 0 THEN
            v_table_ddl := v_table_ddl || '  "' || v_colrec.column_name || '" ';
          ELSE


### PR DESCRIPTION
Currently, columns with the same names as reserved keywords (e.g. desc, and, or) are not quoted, unlike columns with capital letters in them are (e.g. productId). Now these columns are quoted just like camelCase ones. The reserved keywords are fetched using the `pg_get_keywords()` function.

Below are screenshots of the changes:

**Old:**
![image](https://github.com/supabase/supabase/assets/51780559/687834eb-e32c-4eab-a408-6e415b361b9e)

**New:**
![image](https://github.com/supabase/supabase/assets/51780559/152b7e16-8554-4006-94b3-0abc3b32d468)
